### PR TITLE
Merge Toggle-post-or-comments into master

### DIFF
--- a/content.css
+++ b/content.css
@@ -7,19 +7,20 @@
 	/*successfully blocks the LIKE#! on all posts*/
 	
 }
-/*block like #s on COMMENTS*/
+
 .UFICommentLikeButton{
 	/*successfully removes LIKE# FROM COMMENTS (not like-emoji)*/
 	
 }
 
 /*BLOCK ENTIRE LIKE BAR, INCLUDING EMOJIS*/
+
 .UFIRow.UFILikeSentence { /*Regular posts: ENTIRE BAR including emoji and #s*/
 	/*display:none;*/
 }
 ._3399._1f6t._4_dr._20h5 {
 	/*sponsored posts, block posts, and top news*/
-	/*Removes entire line, including likes, comments, shares, and views.*/
+	/*Removes entire line, including likes, #comments, #shares, and #views.*/
 	
 }
 .UFICommentReactionsBling{

--- a/content.css
+++ b/content.css
@@ -1,22 +1,21 @@
 /*block like numbers, but not emoji*/
 ._4arz{ 
 	/*successfully blocks the LIKE-NAMES automatically shown on all posts*/
-	display: none;
+	
 }
 ._1g5v{
 	/*successfully blocks the LIKE#! on all posts*/
-	display: none;
+	
 }
 /*block like #s on COMMENTS*/
 .UFICommentLikeButton{
 	/*successfully removes LIKE# FROM COMMENTS (not like-emoji)*/
-	display: none;
+	
 }
 
 /*BLOCK ENTIRE LIKE BAR, INCLUDING EMOJIS*/
 .UFIRow.UFILikeSentence { /*Regular posts: ENTIRE BAR including emoji and #s*/
 	/*display:none;*/
-
 }
 ._3399._1f6t._4_dr._20h5 {
 	/*sponsored posts, block posts, and top news*/

--- a/content.js
+++ b/content.js
@@ -1,13 +1,3 @@
-//check storage to see if comments are enabled
-chrome.storage.sync.get(['commentsClicked'], function(internal){
-	if(internal.commentsClicked){
-		console.log("Storage: comments ARE clicked");
-	}
-	else {
-		console.log("Storage: comments NOT clicked.");
-	}
-});
-
 //use event listener to see if comments enabled
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 	if(request.isCommented) {

--- a/content.js
+++ b/content.js
@@ -6,24 +6,24 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 		$('.UFICommentLikeButton').css('display', "none");
 	}
 	if(request.isCommented == false) {
-		$('.UFICommentLikeButton').css('display', "block");
+		$('.UFICommentLikeButton').css('display', "inline");
 	}
 	if(request.isPosted){
 		$('._1g5v').css('display', "none");
 		$('._4arz').css('display', "none");		
 	}
-	if(request.isPosted ==false)
+	if(request.isPosted ==false){
 		$('._1g5v').css('display', "block"); //not sure if it should be "inline"
 		$('._4arz').css('display', "block");
 	}
 });
 
 chrome.storage.sync.get(['commentsClicked', 'postsClicked'], function(internal){
-	isCommentsContent = internal.commentsClicked;
-	console.log("line 244, internal: " + internal.commentsClicked + "isC: " + isCommentsContent);
+
+	console.log("line 244, internalComments: " + internal.commentsClicked);
+	console.log("line 24, internalPosts: " + internal.postsClicked);
 	//For some weird reason, if statement doesn't work if I use "isCommentsContent"
 	if(internal.commentsClicked){  
-
 		$('.UFICommentLikeButton').css('display', "none");
 	}
 	//For some weird reason, if statement doesn't work if I use "isCommentsContent"

--- a/content.js
+++ b/content.js
@@ -1,2 +1,19 @@
-console.log("This is a test.");
-//try to use document.getElementBYId to add a button?
+//check storage to see if comments are enabled
+chrome.storage.sync.get(['commentsClicked'], function(internal){
+	if(internal.commentsClicked){
+		console.log("Storage: comments ARE clicked");
+	}
+	else {
+		console.log("Storage: comments NOT clicked.");
+	}
+});
+
+//use event listener to see if comments enabled
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
+	if(request.isCommented) {
+		console.log("Event listener: comments ARE clicked");
+	}
+	else {
+		console.log("Event listener: comments NOT clicked");
+	}
+});

--- a/content.js
+++ b/content.js
@@ -3,12 +3,15 @@ var isPostsContent = false;
 //use event listener to see if comments enabled
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 	if(request.isCommented) {	
+		//this is the class that controls the # of likes shown on comments
 		$('.UFICommentLikeButton').css('display', "none");
 	}
 	if(request.isCommented == false) {
 		$('.UFICommentLikeButton').css('display', "inline");
 	}
 	if(request.isPosted){
+		//1st is class that controls the names of friends who've liked a post
+		//2nd is class that controls # of ppl besides your friends who've liked post
 		$('._1g5v').css('display', "none");
 		$('._4arz').css('display', "none");		
 	}

--- a/content.js
+++ b/content.js
@@ -1,9 +1,37 @@
+var isCommentsContent = false;
+var isPostsContent = false;
 //use event listener to see if comments enabled
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
-	if(request.isCommented) {
-		console.log("Event listener: comments ARE clicked");
+	if(request.isCommented) {	
+		$('.UFICommentLikeButton').css('display', "none");
 	}
-	else {
-		console.log("Event listener: comments NOT clicked");
+	if(request.isCommented == false) {
+		$('.UFICommentLikeButton').css('display', "block");
+	}
+	if(request.isPosted){
+		$('._1g5v').css('display', "none");
+		$('._4arz').css('display', "none");		
+	}
+	if(request.isPosted ==false)
+		$('._1g5v').css('display', "block"); //not sure if it should be "inline"
+		$('._4arz').css('display', "block");
 	}
 });
+
+chrome.storage.sync.get(['commentsClicked', 'postsClicked'], function(internal){
+	isCommentsContent = internal.commentsClicked;
+	console.log("line 244, internal: " + internal.commentsClicked + "isC: " + isCommentsContent);
+	//For some weird reason, if statement doesn't work if I use "isCommentsContent"
+	if(internal.commentsClicked){  
+
+		$('.UFICommentLikeButton').css('display', "none");
+	}
+	//For some weird reason, if statement doesn't work if I use "isCommentsContent"
+	if(internal.postsClicked){  
+		$('._1g5v').css('display', "none");
+		$('._4arz').css('display', "none");
+	}
+});
+
+
+//document.getElementById("rightCol").style.display = 'none';

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "Facebook Likes Hider",
 	"version": "1.0",
-	"description": "Hides the likes on Facebook",
+	"description": "Hides the number of likes on Facebook posts and comments",
 	"permissions": ["*://*.facebook.com/*"],
 	"content_scripts": [
 		{
@@ -19,6 +19,14 @@
 	},
 	"browser_action": {
 		"default_icon": "icon16.png",
-		"default_title": "Word Converter"
-	}
+		"default_title": "Facebook Likes Hider",
+		"default_popup": "popup.html"
+	},
+	"background": {
+		"scripts": ["eventPage.js"],
+		"persistent": false
+	},
+	"permissions": [
+		"storage"
+	]
 }

--- a/popup.html
+++ b/popup.html
@@ -8,5 +8,7 @@
 	<body>
 		<h1>Facebook Likes Hider</h1>
 		<button name="commentsToggleButton">Comments Toggle</button>
+		<h3 id="truthHeader">Neither true nor false.</h3>
+		<h3 id="clickCounter">Number of clicks: 0.</h3>
 	</body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,5 @@
 		<button name ="resetButton">Reset Button</button>
 		<h3 id="postsHeader">Posts are: <span id="postsTruthDiv"> neither true nor false</span></h3>
 		<h3 id="commentsHeader">Comments are: <span id="commentsTruthDiv">neither true nor false.</span></h3>
-		<h3 id="clickCounter">Number of clicks: 0.</h3>
 	</body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,7 @@
 	<body>
 		<h1>Facebook Likes Hider</h1>
 		<button name="commentsToggleButton">Comments Toggle</button>
+		<button name ="resetButton">Reset Button</button>
 		<h3 id="truthHeader">Neither true nor false.</h3>
 		<h3 id="clickCounter">Number of clicks: 0.</h3>
 	</body>

--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,7 @@
 		<h1>Facebook Likes Hider</h1>
 		<button name="commentsToggleButton">Comments Toggle</button>
 		<button name ="resetButton">Reset Button</button>
-		<h3 id="truthHeader">Neither true nor false.</h3>
+		<h3 id="commentsHeader">Comments are: <span id="commentsTruthDiv">neither true nor false.</span></h3>
 		<h3 id="clickCounter">Number of clicks: 0.</h3>
 	</body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -7,8 +7,10 @@
 	</head>
 	<body>
 		<h1>Facebook Likes Hider</h1>
+		<button name="postsToggleButton">Posts Toggle</button>
 		<button name="commentsToggleButton">Comments Toggle</button>
 		<button name ="resetButton">Reset Button</button>
+		<h3 id="postsHeader">Posts are: <span id="postsTruthDiv"> neither true nor false</span></h3>
 		<h3 id="commentsHeader">Comments are: <span id="commentsTruthDiv">neither true nor false.</span></h3>
 		<h3 id="clickCounter">Number of clicks: 0.</h3>
 	</body>

--- a/popup.html
+++ b/popup.html
@@ -7,5 +7,6 @@
 	</head>
 	<body>
 		<h1>Facebook Likes Hider</h1>
+		<button name="commentsToggleButton">Comments Toggle</button>
 	</body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Facebook Likes Hider </title>
+		<script src = "jquery-3.3.1.min.js"></script>
+		<script src="popup.js"></script>
+	</head>
+	<body>
+		<h1>Facebook Likes Hider</h1>
+	</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,32 @@
+$(function(){
+	chrome.storage.sync.get(['clickNumber', 'isClicked'], function(internal){
+		if(internal.clickNumber){
+			$('#clickCounter').text("Number of clicks: " + internal.clickNumber);
+		}
+		if(internal.isClicked){
+			$('#truthHeader').text(internal.isClicked.toString());
+		}
+	});
+
+	$("button[name='commentsToggleButton'").click(function(){
+		console.log("Hello");
+
+		chrome.storage.sync.get(['clickNumber', 'isClicked'], function(internal){
+			var newIsClicked = true;
+			var newClickNumber = 1;
+			if(internal.clickNumber){
+				newClickNumber += internal.clickNumber; 
+			}
+			if(internal.isClicked){
+				newIsClicked = !internal.isClicked;
+			}
+
+			chrome.storage.sync.set({'clickNumber':newClickNumber, 'isClicked':newIsClicked});
+			$('#clickCounter').text("Number of clicks: " + newClickNumber);
+			$('#truthHeader').text(newIsClicked.toString());
+
+		});
+		
+
+	});
+});

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,8 @@
 $(function(){
+	//Check for existing stored values, and set text in popup to that
 	chrome.storage.sync.get(['clickNumber', 'isClicked'], function(internal){
-		if(internal.clickNumber){
+		//If clickNumber or truthHeader already exists, change the text to it
+		if(internal.clickNumber){ 
 			$('#clickCounter').text("Number of clicks: " + internal.clickNumber);
 		}
 		if(internal.isClicked){
@@ -8,12 +10,14 @@ $(function(){
 		}
 	});
 
+	//If the button is clicked, increment the clickNumber and toggle isClicked
 	$("button[name='commentsToggleButton'").click(function(){
 		console.log("Hello");
 
 		chrome.storage.sync.get(['clickNumber', 'isClicked'], function(internal){
-			var newIsClicked = true;
 			var newClickNumber = 1;
+			var newIsClicked = true;
+			//Set the new values to the old values /if they exist/
 			if(internal.clickNumber){
 				newClickNumber += internal.clickNumber; 
 			}
@@ -21,12 +25,12 @@ $(function(){
 				newIsClicked = !internal.isClicked;
 			}
 
+			//Store the new values for clickNumber and isClicked
 			chrome.storage.sync.set({'clickNumber':newClickNumber, 'isClicked':newIsClicked});
+			//DIsplay the new values on the popup
 			$('#clickCounter').text("Number of clicks: " + newClickNumber);
 			$('#truthHeader').text(newIsClicked.toString());
 
 		});
-		
-
 	});
 });

--- a/popup.js
+++ b/popup.js
@@ -1,48 +1,70 @@
 $(function(){
 	//Check for existing stored values, and set text in popup to that
-	chrome.storage.sync.get(['clickNumber', 'commentsClicked'], function(internal){
+	chrome.storage.sync.get(['postsClicked', 'commentsClicked'], function(internal){
 		//If clickNumber or commentsTruthDiv already exists, change the text to it
-		if(internal.clickNumber){ 
-			$('#clickCounter').text("Number of clicks: " + internal.clickNumber);
+		if(internal.postsClicked){ 
+			$('#postsTruthDiv').text("Posts: " + internal.postsClicked.toString());
 		}
 		if(internal.commentsClicked){
-			$('#commentsTruthDiv').text(internal.commentsClicked.toString());
+			$('#commentsTruthDiv').text("Comments" + internal.commentsClicked.toString());
 		}
 	});
 
 	//If the button is clicked, increment the clickNumber and toggle commentsClicked
 	$("button[name='commentsToggleButton'").click(function(){
-		console.log("Hello");
+		var newCommentsClicked = true;
+		chrome.storage.sync.get(['commentsClicked'], function(internal){
 
-		chrome.storage.sync.get(['clickNumber', 'commentsClicked'], function(internal){
-			var newClickNumber = 1;
-			var newCommentsClicked = true;
 			//Set the new values to the old values /if they exist/
-			if(internal.clickNumber){
-				newClickNumber += internal.clickNumber; 
-			}
 			if(internal.commentsClicked){
 				newCommentsClicked = !internal.commentsClicked;
 			}
-
 			//Store the new values for clickNumber and commentsClicked
-			chrome.storage.sync.set({'clickNumber':newClickNumber, 'commentsClicked':newCommentsClicked});
+			chrome.storage.sync.set({'commentsClicked':newCommentsClicked});
 			//DIsplay the new values on the popup
-			$('#clickCounter').text("Number of clicks: " + newClickNumber);
 			$('#commentsTruthDiv').text(newCommentsClicked.toString());
 			//Send a message to content script
+
 			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
 				chrome.tabs.sendMessage(tabs[0].id, {
 					isCommented: newCommentsClicked
 				});
 			});
+		});
+	});
+	$("button[name='postsToggleButton'").click(function(){
+		var newPostsClicked = true;
+		chrome.storage.sync.get(['postsClicked'], function(internal){
 
+			//Set the new values to the old values /if they exist/
+			if(internal.postsClicked){
+				newPostsClicked = !internal.postsClicked;
+			}
+			//Store the new values for clickNumber and commentsClicked
+			chrome.storage.sync.set({'postsClicked':newPostsClicked});
+			//DIsplay the new values on the popup
+			$('#postsTruthDiv').text(newPostsClicked.toString());
+			//Send a message to content script
+
+			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+				chrome.tabs.sendMessage(tabs[0].id, {
+					isPosted: newPostsClicked
+				});
+			});
 		});
 	});
 
+	//Reset button resets everything
 	$("button[name='resetButton']").click(function(){
-		chrome.storage.sync.set({'clickNumber':0, 'commentsClicked':false});
-		$('#clickCounter').text("Number of clicks: " + 0);
+		chrome.storage.sync.set({'commentsClicked':false, 'postsClicked':false});
 		$('#commentsTruthDiv').text(false.toString());
+		$('#postsTruthDiv').text(false.toString());
+
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			chrome.tabs.sendMessage(tabs[0].id, {
+				isCommented: false,
+				isPosted: false
+			});
+		});
 	});
 });

--- a/popup.js
+++ b/popup.js
@@ -3,10 +3,10 @@ $(function(){
 	chrome.storage.sync.get(['postsClicked', 'commentsClicked'], function(internal){
 		//If clickNumber or commentsTruthDiv already exists, change the text to it
 		if(internal.postsClicked){ 
-			$('#postsTruthDiv').text("Posts: " + internal.postsClicked.toString());
+			$('#postsTruthDiv').text(internal.postsClicked.toString());
 		}
 		if(internal.commentsClicked){
-			$('#commentsTruthDiv').text("Comments" + internal.commentsClicked.toString());
+			$('#commentsTruthDiv').text(internal.commentsClicked.toString());
 		}
 	});
 

--- a/popup.js
+++ b/popup.js
@@ -1,22 +1,22 @@
 $(function(){
 	//Check for existing stored values, and set text in popup to that
 	chrome.storage.sync.get(['postsClicked', 'commentsClicked'], function(internal){
-		//If clickNumber or commentsTruthDiv already exists, change the text to it
-		if(internal.postsClicked){ 
+		//If posts-/commentsTruthDiv already exist, change the text to the stored value
+		//Because it's a boolean, in order to check if it exists, must see if its type is 'undefined'
+		if(typeof internal.postsClicked !== 'undefined'){ 
 			$('#postsTruthDiv').text(internal.postsClicked.toString());
 		}
-		if(internal.commentsClicked){
+		if(typeof internal.commentsClicked !== 'undefined'){
 			$('#commentsTruthDiv').text(internal.commentsClicked.toString());
 		}
 	});
 
-	//If the button is clicked, increment the clickNumber and toggle commentsClicked
+	//If the commentsToggle button is clicked, toggle the removal of likes on comments on or off 
+	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
 	$("button[name='commentsToggleButton'").click(function(){
-		var newCommentsClicked = true;
+		var newCommentsClicked = true; //Will update new var based on old stored values
 		chrome.storage.sync.get(['commentsClicked'], function(internal){
-
-			//Set the new values to the old values /if they exist/
-			if(internal.commentsClicked){
+			if(typeof internal.commentsClicked !== 'undefined'){
 				newCommentsClicked = !internal.commentsClicked;
 			}
 			//Store the new values for clickNumber and commentsClicked
@@ -26,30 +26,36 @@ $(function(){
 			//Send a message to content script
 
 			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+				//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 				chrome.tabs.sendMessage(tabs[0].id, {
 					isCommented: newCommentsClicked
-				});
+				});				
+				//so message is sent to 0th tab
 			});
 		});
 	});
+	//If the posts button is clicked, toggle the removal of likes on comments on or off 
+	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
 	$("button[name='postsToggleButton'").click(function(){
 		var newPostsClicked = true;
-		chrome.storage.sync.get(['postsClicked'], function(internal){
+		chrome.storage.sync.get(['postsClicked'], function(internal){ 
 
 			//Set the new values to the old values /if they exist/
-			if(internal.postsClicked){
+			if(typeof internal.postsClicked !== 'undefined'){ 
+			//!== 'undefined' ensures that if the Boolean exists but equals F, it returns T
 				newPostsClicked = !internal.postsClicked;
 			}
-			//Store the new values for clickNumber and commentsClicked
+			//Store the new values for postsClicked
 			chrome.storage.sync.set({'postsClicked':newPostsClicked});
 			//DIsplay the new values on the popup
 			$('#postsTruthDiv').text(newPostsClicked.toString());
 			//Send a message to content script
-
 			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+				//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 				chrome.tabs.sendMessage(tabs[0].id, {
 					isPosted: newPostsClicked
 				});
+				//so message is sent to 0th tab
 			});
 		});
 	});

--- a/popup.js
+++ b/popup.js
@@ -1,41 +1,47 @@
 $(function(){
 	//Check for existing stored values, and set text in popup to that
-	chrome.storage.sync.get(['clickNumber', 'isClicked'], function(internal){
+	chrome.storage.sync.get(['clickNumber', 'commentsClicked'], function(internal){
 		//If clickNumber or truthHeader already exists, change the text to it
 		if(internal.clickNumber){ 
 			$('#clickCounter').text("Number of clicks: " + internal.clickNumber);
 		}
-		if(internal.isClicked){
-			$('#truthHeader').text(internal.isClicked.toString());
+		if(internal.commentsClicked){
+			$('#truthHeader').text(internal.commentsClicked.toString());
 		}
 	});
 
-	//If the button is clicked, increment the clickNumber and toggle isClicked
+	//If the button is clicked, increment the clickNumber and toggle commentsClicked
 	$("button[name='commentsToggleButton'").click(function(){
 		console.log("Hello");
 
-		chrome.storage.sync.get(['clickNumber', 'isClicked'], function(internal){
+		chrome.storage.sync.get(['clickNumber', 'commentsClicked'], function(internal){
 			var newClickNumber = 1;
-			var newIsClicked = true;
+			var newCommentsClicked = true;
 			//Set the new values to the old values /if they exist/
 			if(internal.clickNumber){
 				newClickNumber += internal.clickNumber; 
 			}
-			if(internal.isClicked){
-				newIsClicked = !internal.isClicked;
+			if(internal.commentsClicked){
+				newCommentsClicked = !internal.commentsClicked;
 			}
 
-			//Store the new values for clickNumber and isClicked
-			chrome.storage.sync.set({'clickNumber':newClickNumber, 'isClicked':newIsClicked});
+			//Store the new values for clickNumber and commentsClicked
+			chrome.storage.sync.set({'clickNumber':newClickNumber, 'commentsClicked':newCommentsClicked});
 			//DIsplay the new values on the popup
 			$('#clickCounter').text("Number of clicks: " + newClickNumber);
-			$('#truthHeader').text(newIsClicked.toString());
+			$('#truthHeader').text(newCommentsClicked.toString());
+			//Send a message to content script
+			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+				chrome.tabs.sendMessage(tabs[0].id, {
+					isCommented: newCommentsClicked
+				});
+			});
 
 		});
 	});
 
 	$("button[name='resetButton']").click(function(){
-		chrome.storage.sync.set({'clickNumber':0, 'isClicked':false});
+		chrome.storage.sync.set({'clickNumber':0, 'commentsClicked':false});
 		$('#clickCounter').text("Number of clicks: " + 0);
 		$('#truthHeader').text(false.toString());
 	});

--- a/popup.js
+++ b/popup.js
@@ -33,4 +33,10 @@ $(function(){
 
 		});
 	});
+
+	$("button[name='resetButton']").click(function(){
+		chrome.storage.sync.set({'clickNumber':0, 'isClicked':false});
+		$('#clickCounter').text("Number of clicks: " + 0);
+		$('#truthHeader').text(false.toString());
+	});
 });

--- a/popup.js
+++ b/popup.js
@@ -1,12 +1,12 @@
 $(function(){
 	//Check for existing stored values, and set text in popup to that
 	chrome.storage.sync.get(['clickNumber', 'commentsClicked'], function(internal){
-		//If clickNumber or truthHeader already exists, change the text to it
+		//If clickNumber or commentsTruthDiv already exists, change the text to it
 		if(internal.clickNumber){ 
 			$('#clickCounter').text("Number of clicks: " + internal.clickNumber);
 		}
 		if(internal.commentsClicked){
-			$('#truthHeader').text(internal.commentsClicked.toString());
+			$('#commentsTruthDiv').text(internal.commentsClicked.toString());
 		}
 	});
 
@@ -29,7 +29,7 @@ $(function(){
 			chrome.storage.sync.set({'clickNumber':newClickNumber, 'commentsClicked':newCommentsClicked});
 			//DIsplay the new values on the popup
 			$('#clickCounter').text("Number of clicks: " + newClickNumber);
-			$('#truthHeader').text(newCommentsClicked.toString());
+			$('#commentsTruthDiv').text(newCommentsClicked.toString());
 			//Send a message to content script
 			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
 				chrome.tabs.sendMessage(tabs[0].id, {
@@ -43,6 +43,6 @@ $(function(){
 	$("button[name='resetButton']").click(function(){
 		chrome.storage.sync.set({'clickNumber':0, 'commentsClicked':false});
 		$('#clickCounter').text("Number of clicks: " + 0);
-		$('#truthHeader').text(false.toString());
+		$('#commentsTruthDiv').text(false.toString());
 	});
 });


### PR DESCRIPTION
Right now, this branch lets you click a button for posts and comments each to hide or un-hide the # of likes.

It automatically works when you open up FB, using your previous settings.

However there are 2 bugs.
1. If you "load new comments" or open up a photo, then the likes won't automatically be hideen. You have to go to popup and un-hide then hide to properly hide.
2. If you make a change in the popup in another tab while FB is open, when you go back to FB the changes won't automatically be reflected.