### PR TITLE
Remove like emoji (into) Master

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,24 +1,25 @@
 //use event listener to see if comments enabled
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
-	if(request.postMsg == 0) {	
-		//this is the class that controls the # of likes shown on comments
-		$('.UFICommentLikeButton').css('display', "inline");
+	if(request.postMsg == 0) {
+		//1st is class that controls the names of friends who've liked a post
+		//2nd is class that controls # of ppl besides your friends who've liked post
+		$('._1g5v').css('display', "block"); 
+		$('._4arz').css('display', "block");	
+		
 	}
 	if(request.postMsg == 1) {
-		$('.UFICommentLikeButton').css('display', "none");
+		$('._1g5v').css('display', "none");
+		$('._4arz').css('display', "none");	
 	}
 	//TODO: == 2 for post and comments, and will need to update
 	//	in both 0 and 1 to unhide the things 2 hides
 
 	if(request.commentMsg == 0){
-		//1st is class that controls the names of friends who've liked a post
-		//2nd is class that controls # of ppl besides your friends who've liked post
-		$('._1g5v').css('display', "block"); 
-		$('._4arz').css('display', "block");
+		//this is the class that controls the # of likes shown on comments
+		$('.UFICommentLikeButton').css('display', "inline");
 	}
 	if(request.commentMsg == 1){
-		$('._1g5v').css('display', "none");
-		$('._4arz').css('display', "none");	
+		$('.UFICommentLikeButton').css('display', "none");
 	}
 });
 

--- a/content.js
+++ b/content.js
@@ -3,13 +3,20 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 	if(request.postMsg == 0) {
 		$('._1g5v').css('display', "block");//names of specific-friends who've liked a post
 		$('._4arz').css('display', "block");//#of non-specificfriends who've liked a post
+		$('.UFIRow.UFILikeSentence').css('display', "block");
+		$('._3399._1f6t._4_dr._20h5').css('display',"block");
 	}
-	if(request.postMsg == 1) {
+	if(request.postMsg == 1) {//Show emojis, not #likes
 		$('._1g5v').css('display', "none");
 		$('._4arz').css('display', "none");	
+		$('.UFIRow.UFILikeSentence').css('display', "block");
+		$('._3399._1f6t._4_dr._20h5').css('display',"block");
 	}
 	if(request.postMsg ==2){
-
+		$('._1g5v').css('display', "block");
+		$('._4arz').css('display', "block");
+		$('.UFIRow.UFILikeSentence').css('display', "none");
+		$('._3399._1f6t._4_dr._20h5').css('display',"none");
 	}
 	//TODO: == 2 for post and comments, and will need to update
 	//	in both 0 and 1 to unhide the things 2 hides
@@ -31,12 +38,24 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 });
 
 chrome.storage.sync.get(['post', 'comment'], function(internal){
+	//Get values from chrome storage
+	//Only runs on startup of page
+	//If, during last session, user blocked something, it's stored in storage
+	//and retrieved and automatically blocked upon next startup
+
 	console.log("post: " + internal.post+", comment: "+internal.comment);
 	if(internal.post == 1){  
 		$('._1g5v').css('display', "none");
-		$('._4arz').css('display', "none");
+		$('._4arz').css('display', "none");	
+		$('.UFIRow.UFILikeSentence').css('display', "block");
+		$('._3399._1f6t._4_dr._20h5').css('display',"block");
 	}
-	//TODO == 2 for post and comments
+	if(internal.post ==2){
+		$('._1g5v').css('display', "block");
+		$('._4arz').css('display', "block");
+		$('.UFIRow.UFILikeSentence').css('display', "none");
+		$('._3399._1f6t._4_dr._20h5').css('display',"none");
+	}
 	if(internal.comment == 1){ //show emoji, not #likes
 		console.log("comment: "+internal.comment+", console.log line41");
 		$('.UFICommentLikeButton').css('display', "none");

--- a/content.js
+++ b/content.js
@@ -31,17 +31,20 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 });
 
 chrome.storage.sync.get(['post', 'comment'], function(internal){
+	console.log("post: " + internal.post+", comment: "+internal.comment);
 	if(internal.post == 1){  
 		$('._1g5v').css('display', "none");
 		$('._4arz').css('display', "none");
 	}
 	//TODO == 2 for post and comments
-	if(request.commentMsg == 1){ //show emoji, not #likes
+	if(internal.comment == 1){ //show emoji, not #likes
+		console.log("comment: "+internal.comment+", console.log line41");
 		$('.UFICommentLikeButton').css('display', "none");
 		$('.UFICommentReactionsBling').css('display', "inline");
 	}
-	if(request.commentMsg == 2){//show emoji class, but remove class that contains emojis 
+	if(internal.comment == 2){//show emoji class, but remove class that contains emojis 
 		//	AND #likes
+		console.log("comment: "+internal.comment+", console.log line47");
 		$('.UFICommentLikeButton').css('display', "inline");
 		$('.UFICommentReactionsBling').css('display', "none");
 	}

--- a/content.js
+++ b/content.js
@@ -1,29 +1,33 @@
 //use event listener to see if comments enabled
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
-	if(request.isCommented) {	
+	if(request.postMsg == 0) {	
 		//this is the class that controls the # of likes shown on comments
-		$('.UFICommentLikeButton').css('display', "none");
-	}
-	if(request.isCommented == false) {
 		$('.UFICommentLikeButton').css('display', "inline");
 	}
-	if(request.isPosted){
+	if(request.postMsg == 1) {
+		$('.UFICommentLikeButton').css('display', "none");
+	}
+	//TODO: == 2 for post and comments, and will need to update
+	//	in both 0 and 1 to unhide the things 2 hides
+
+	if(request.commentMsg == 0){
 		//1st is class that controls the names of friends who've liked a post
 		//2nd is class that controls # of ppl besides your friends who've liked post
-		$('._1g5v').css('display', "none");
-		$('._4arz').css('display', "none");		
-	}
-	if(request.isPosted ==false){
-		$('._1g5v').css('display', "block"); //not sure if it should be "inline"
+		$('._1g5v').css('display', "block"); 
 		$('._4arz').css('display', "block");
+	}
+	if(request.commentMsg == 1){
+		$('._1g5v').css('display', "none");
+		$('._4arz').css('display', "none");	
 	}
 });
 
-chrome.storage.sync.get(['commentsClicked', 'postsClicked'], function(internal){
-	if(internal.commentsClicked){  
+chrome.storage.sync.get(['post', 'comment'], function(internal){
+	if(internal.post == 1){  
 		$('.UFICommentLikeButton').css('display', "none");
 	}
-	if(internal.postsClicked){  
+	//TODO == 2 for post and comments
+	if(internal.comment == 1){  
 		$('._1g5v').css('display', "none");
 		$('._4arz').css('display', "none");
 	}

--- a/content.js
+++ b/content.js
@@ -27,7 +27,6 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 		//	AND #likes
 		$('.UFICommentLikeButton').css('display', "inline");
 		$('.UFICommentReactionsBling').css('display', "none");
-
 	}
 });
 
@@ -37,8 +36,13 @@ chrome.storage.sync.get(['post', 'comment'], function(internal){
 		$('._4arz').css('display', "none");
 	}
 	//TODO == 2 for post and comments
-	if(internal.comment == 1){  
+	if(request.commentMsg == 1){ //show emoji, not #likes
 		$('.UFICommentLikeButton').css('display', "none");
-
+		$('.UFICommentReactionsBling').css('display', "inline");
+	}
+	if(request.commentMsg == 2){//show emoji class, but remove class that contains emojis 
+		//	AND #likes
+		$('.UFICommentLikeButton').css('display', "inline");
+		$('.UFICommentReactionsBling').css('display', "none");
 	}
 });

--- a/content.js
+++ b/content.js
@@ -17,19 +17,27 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 	if(request.commentMsg == 0){
 		//this is the class that controls the # of likes shown on comments
 		$('.UFICommentLikeButton').css('display', "inline");
+		$('.UFICommentReactionsBling').css('display', "inline");
 	}
 	if(request.commentMsg == 1){
 		$('.UFICommentLikeButton').css('display', "none");
+		$('.UFICommentReactionsBling').css('display', "inline");
+	}
+	if(request.postMsg == 2){
+		$('.UFICommentLikeButton').css('display', "inline");
+		$('.UFICommentReactionsBling').css('display', "none");
+
 	}
 });
 
 chrome.storage.sync.get(['post', 'comment'], function(internal){
 	if(internal.post == 1){  
-		$('.UFICommentLikeButton').css('display', "none");
+		$('._1g5v').css('display', "none");
+		$('._4arz').css('display', "none");
 	}
 	//TODO == 2 for post and comments
 	if(internal.comment == 1){  
-		$('._1g5v').css('display', "none");
-		$('._4arz').css('display', "none");
+		$('.UFICommentLikeButton').css('display', "none");
+
 	}
 });

--- a/content.js
+++ b/content.js
@@ -1,29 +1,30 @@
 //use event listener to see if comments enabled
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 	if(request.postMsg == 0) {
-		//1st is class that controls the names of friends who've liked a post
-		//2nd is class that controls # of ppl besides your friends who've liked post
-		$('._1g5v').css('display', "block"); 
-		$('._4arz').css('display', "block");	
-		
+		$('._1g5v').css('display', "block");//names of specific-friends who've liked a post
+		$('._4arz').css('display', "block");//#of non-specificfriends who've liked a post
 	}
 	if(request.postMsg == 1) {
 		$('._1g5v').css('display', "none");
 		$('._4arz').css('display', "none");	
+	}
+	if(request.postMsg ==2){
+
 	}
 	//TODO: == 2 for post and comments, and will need to update
 	//	in both 0 and 1 to unhide the things 2 hides
 
 	if(request.commentMsg == 0){
 		//this is the class that controls the # of likes shown on comments
-		$('.UFICommentLikeButton').css('display', "inline");
-		$('.UFICommentReactionsBling').css('display', "inline");
+		$('.UFICommentLikeButton').css('display', "inline");//#of likes on comment
+		$('.UFICommentReactionsBling').css('display', "inline");//emojis on comment
 	}
-	if(request.commentMsg == 1){
+	if(request.commentMsg == 1){ //show emoji, not #likes
 		$('.UFICommentLikeButton').css('display', "none");
 		$('.UFICommentReactionsBling').css('display', "inline");
 	}
-	if(request.postMsg == 2){
+	if(request.commentMsg == 2){//show emoji class, but remove class that contains emojis 
+		//	AND #likes
 		$('.UFICommentLikeButton').css('display', "inline");
 		$('.UFICommentReactionsBling').css('display', "none");
 

--- a/popup.html
+++ b/popup.html
@@ -13,7 +13,7 @@
 				<button name="post-hide-likes">Posts Hide Likes</button>
 				<button name="post-hide-all">Posts Hide All</button>
 			</div>
-			<h3 id="postHeader">Posts' likes are: <span id="postStatus"> neither true nor false</span></h3>
+			<h3 id="postHeader">Posts' likes are: <span id="postStatus">no info stored.</span></h3>
 		</div>
 		<div class = "comment-group">
 			<div class = "comment-button-group">
@@ -21,7 +21,7 @@
 				<button name="comment-hide-likes">Comments Hide Likes</button>
 				<button name="comment-hide-all">Comments Hide All</button>
 			</div>
-			<h3 id="commentHeader">Comments' likes are: <span id="commentStatus">neither true nor false.</span></h3>
+			<h3 id="commentHeader">Comments' likes are: <span id="commentStatus">no info stored.</span></h3>
 		</div>
 		<button name ="resetButton">Reset Button</button>
 		

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,7 @@
 			<div class = "post-button-group">
 				<button name="post-unhide">Posts Unhide All</button>
 				<button name="post-hide-likes">Posts Hide Likes</button>
-				<button name="post-like-all">Posts Hide All</button>
+				<button name="post-hide-all">Posts Hide All</button>
 			</div>
 			<h3 id="postHeader">Posts' likes are: <span id="postStatus"> neither true nor false</span></h3>
 		</div>
@@ -19,7 +19,7 @@
 			<div class = "comment-button-group">
 				<button name="comment-unhide">Comments Unhide All</button>
 				<button name="comment-hide-likes">Comments Hide Likes</button>
-				<button name="comment-like-all">Comments Hide All</button>
+				<button name="comment-hide-all">Comments Hide All</button>
 			</div>
 			<h3 id="commentHeader">Comments' likes are: <span id="commentStatus">neither true nor false.</span></h3>
 		</div>

--- a/popup.html
+++ b/popup.html
@@ -13,7 +13,7 @@
 				<button name="post-hide-likes">Posts Hide Likes</button>
 				<button name="post-like-all">Posts Hide All</button>
 			</div>
-			<h3 id="postHeader">Posts' likes are: <span id="postsStatus"> neither true nor false</span></h3>
+			<h3 id="postHeader">Posts' likes are: <span id="postStatus"> neither true nor false</span></h3>
 		</div>
 		<div class = "comment-group">
 			<div class = "comment-button-group">

--- a/popup.html
+++ b/popup.html
@@ -7,10 +7,24 @@
 	</head>
 	<body>
 		<h1>Facebook Likes Hider</h1>
-		<button name="postsToggleButton">Posts Toggle</button>
-		<button name="commentsToggleButton">Comments Toggle</button>
+		<div class = "post-group">
+			<div class = "post-button-group">
+				<button name="post-unhide">Posts Unhide All</button>
+				<button name="post-hide-likes">Posts Hide Likes</button>
+				<button name="post-like-all">Posts Hide All</button>
+			</div>
+			<h3 id="postHeader">Posts' likes are: <span id="postsStatus"> neither true nor false</span></h3>
+		</div>
+		<div class = "comment-group">
+			<div class = "comment-button-group">
+				<button name="comment-unhide">Comments Unhide All</button>
+				<button name="comment-hide-likes">Comments Hide Likes</button>
+				<button name="comment-like-all">Comments Hide All</button>
+			</div>
+			<h3 id="commentHeader">Comments' likes are: <span id="commentStatus">neither true nor false.</span></h3>
+		</div>
 		<button name ="resetButton">Reset Button</button>
-		<h3 id="postsHeader">Posts' likes are: <span id="postsTruthDiv"> neither true nor false</span></h3>
-		<h3 id="commentsHeader">Comments' likes are: <span id="commentsTruthDiv">neither true nor false.</span></h3>
+		
+		
 	</body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,8 +1,9 @@
 $(function(){
 	//Check for existing stored values, and set text in popup to that
 	chrome.storage.sync.get(['post', 'comment'], function(internal){
-		//If posts-/commentsTruthDiv already exist, change the text to the stored value
-		//Because it's a boolean, in order to check if it exists, must see if its type is 'undefined'
+		//For posts and comments, set text to the proper word based on chrome storage
+		//	using a 0-2 system. 0=hidden, 1=only likes hidden, 2=everything hidden
+		//" !=='undefined' " is how I ensure that it exists, even if it's a boolean!
 		if(typeof internal.post !== 'undefined'){ 
 			if(internal.post == 0){
 				$('#postStatus').text("unhidden");
@@ -33,7 +34,9 @@ $(function(){
 		}
 	});
 
-	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
+	//For each of the 6 buttons (3 each P and C) do the same thing:
+	//When clicked, set the corresponding val in storage to the new val
+	//and send a message to the content-script
 	$("button[name='post-unhide'").click(function(){
 		var newPost = 0;
 		chrome.storage.sync.set({'post': newPost});
@@ -50,11 +53,9 @@ $(function(){
 		var newPost = 1;
 		chrome.storage.sync.set({'post': newPost});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
-			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
 				postMsg: 1
 			});				
-			//so message is sent to 0th tab
 		});
 		$('#postStatus').text("likes hidden");
 	});
@@ -62,11 +63,9 @@ $(function(){
 		var newPost = 2;
 		chrome.storage.sync.set({'post': newPost});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
-			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
 				postMsg: 2
 			});				
-			//so message is sent to 0th tab
 		});
 		$('#postStatus').text("all is hidden");
 	});
@@ -77,11 +76,9 @@ $(function(){
 		var newComment = 0;
 		chrome.storage.sync.set({'comment': newComment});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
-			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
 				commentMsg: 0
 			});				
-			//so message is sent to 0th tab
 		});
 		$('#commentStatus').text("unhidden");
 	});
@@ -89,11 +86,9 @@ $(function(){
 		var newComment = 1;
 		chrome.storage.sync.set({'comment': newComment});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
-			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
 				commentMsg: 1
 			});				
-			//so message is sent to 0th tab
 		});
 		$('#commentStatus').text("likes hidden");
 	});
@@ -101,11 +96,9 @@ $(function(){
 		var newComment = 2;
 		chrome.storage.sync.set({'comment': newComment});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
-			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
 				commentMsg: 2
 			});				
-			//so message is sent to 0th tab
 		});
 		$('#commentStatus').text("all is hidden");
 	});

--- a/popup.js
+++ b/popup.js
@@ -19,13 +19,13 @@ $(function(){
 			}
 		}
 		if(typeof internal.comment !== 'undefined'){
-			if(internal.post == 0){
+			if(internal.comment == 0){
 				$('#commentStatus').text("unhidden");
 			}
-			else if(internal.post == 1){
+			else if(internal.comment == 1){
 				$('#commentStatus').text("likes hidden");
 			}
-			else if(internal.post == 2){
+			else if(internal.comment == 2){
 				$('#commentStatus').text("all is hidden");
 			}
 			else{

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,9 @@
+
+/*
 $(function(){
 	//Check for existing stored values, and set text in popup to that
-	chrome.storage.sync.get(['postsClicked', 'commentsClicked'], function(internal){
+	chrome.storage.sync.get(['postsClicked', 'commentsClicked'], 
+		function(internal){
 		//If posts-/commentsTruthDiv already exist, change the text to the stored value
 		//Because it's a boolean, in order to check if it exists, must see if its type is 'undefined'
 		if(typeof internal.postsClicked !== 'undefined'){ 
@@ -97,3 +100,4 @@ $(function(){
 		});
 	});
 });
+*/

--- a/popup.js
+++ b/popup.js
@@ -1,31 +1,35 @@
 
-/*
+
 $(function(){
 	//Check for existing stored values, and set text in popup to that
-	chrome.storage.sync.get(['postsClicked', 'commentsClicked'], 
+	chrome.storage.sync.get(['post', 'comment'], 
 		function(internal){
 		//If posts-/commentsTruthDiv already exist, change the text to the stored value
 		//Because it's a boolean, in order to check if it exists, must see if its type is 'undefined'
-		if(typeof internal.postsClicked !== 'undefined'){ 
-			//$('#postsTruthDiv').text(internal.postsClicked.toString());
-			if(internal.postsClicked){
-				$('#postsTruthDiv').text("hidden");
+		if(typeof internal.post !== 'undefined'){ 
+			if(internal.post == 0){
+				$('#postStatus').text("hidden");
 			}
-			else{
-				$('#postsTruthDiv').text("unhidden");
+			elif(internal.post == 1){
+				$('#postStatus').text("likes are hidden");
+			}
+			elif(internal.post == 2){
+				$('#postStatus').text("all is hidden");
 			}
 		}
-		if(typeof internal.commentsClicked !== 'undefined'){
-			//$('#commentsTruthDiv').text(internal.commentsClicked.toString());
-			if(internal.commentsClicked){
-				$('#commentsTruthDiv').text("hidden");
+		if(typeof internal.comment !== 'undefined'){
+			if(internal.post == 0){
+				$('#commentStatus').text("hidden");
 			}
-			else{
-				$('#commentsTruthDiv').text("unhidden");
+			elif(internal.post == 1){
+				$('#commentStatus').text("likes are hidden");
+			}
+			elif(internal.post == 2){
+				$('#commentStatus').text("all is hidden");
 			}
 		}
 	});
-
+/*
 	//If the commentsToggle button is clicked, toggle the removal of likes on comments on or off 
 	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
 	$("button[name='commentsToggleButton'").click(function(){

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,3 @@
-
-
 $(function(){
 	//Check for existing stored values, and set text in popup to that
 	chrome.storage.sync.get(['post', 'comment'], 
@@ -16,6 +14,9 @@ $(function(){
 			elif(internal.post == 2){
 				$('#postStatus').text("all is hidden");
 			}
+			else{
+				$('#postStatus').text("Error #1!");
+			}
 		}
 		if(typeof internal.comment !== 'undefined'){
 			if(internal.post == 0){
@@ -27,38 +28,25 @@ $(function(){
 			elif(internal.post == 2){
 				$('#commentStatus').text("all is hidden");
 			}
+			else{
+				$('#commentStatus').text("Error #2!");
+			}
 		}
 	});
-/*
-	//If the commentsToggle button is clicked, toggle the removal of likes on comments on or off 
-	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
-	$("button[name='commentsToggleButton'").click(function(){
-		var newCommentsClicked = true; //Will update new var based on old stored values
-		chrome.storage.sync.get(['commentsClicked'], function(internal){
-			if(typeof internal.commentsClicked !== 'undefined'){
-				newCommentsClicked = !internal.commentsClicked;
-			}
-			//Store the new values for clickNumber and commentsClicked
-			chrome.storage.sync.set({'commentsClicked':newCommentsClicked});
-			//DIsplay the new values on the popup
-			//$('#commentsTruthDiv').text(newCommentsClicked.toString());
-			if(newCommentsClicked){
-				$('#postsTruthDiv').text("hidden");
-			}
-			else{
-				$('#postsTruthDiv').text("unhidden");
-			}
-			//Send a message to content script
 
-			chrome.tabs.query({active:true, currentWindow:true},function(tabs){
-				//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
-				chrome.tabs.sendMessage(tabs[0].id, {
-					isCommented: newCommentsClicked
-				});				
-				//so message is sent to 0th tab
-			});
+	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
+	$("button[name='post-unhide'").click(function(){
+		var newPost = 0;
+		chrome.storage.sync.set({'comment': newPost});
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
+			chrome.tabs.sendMessage(tabs[0].id, {
+				postMsg: 0
+			});				
+			//so message is sent to 0th tab
 		});
 	});
+/*
 	//If the posts button is clicked, toggle the removal of likes on comments on or off 
 	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
 	$("button[name='postsToggleButton'").click(function(){

--- a/popup.js
+++ b/popup.js
@@ -8,7 +8,7 @@ $(function(){
 				$('#postStatus').text("unhidden");
 			}
 			else if(internal.post == 1){
-				$('#postStatus').text("only likes are hidden");
+				$('#postStatus').text("likes hidden");
 			}
 			else if(internal.post == 2){
 				$('#postStatus').text("all is hidden");
@@ -22,7 +22,7 @@ $(function(){
 				$('#commentStatus').text("unhidden");
 			}
 			else if(internal.post == 1){
-				$('#commentStatus').text("only likes are hidden");
+				$('#commentStatus').text("likes hidden");
 			}
 			else if(internal.post == 2){
 				$('#commentStatus').text("all is hidden");
@@ -36,7 +36,7 @@ $(function(){
 	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once
 	$("button[name='post-unhide'").click(function(){
 		var newPost = 0;
-		chrome.storage.sync.set({'comment': newPost});
+		chrome.storage.sync.set({'post': newPost});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
 			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
@@ -48,7 +48,7 @@ $(function(){
 	});
 	$("button[name='post-hide-likes'").click(function(){
 		var newPost = 1;
-		chrome.storage.sync.set({'comment': newPost});
+		chrome.storage.sync.set({'post': newPost});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
 			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
@@ -56,11 +56,11 @@ $(function(){
 			});				
 			//so message is sent to 0th tab
 		});
-		$('#postStatus').text("only likes are hidden");
+		$('#postStatus').text("likes hidden");
 	});
 	$("button[name='post-hide-all'").click(function(){
 		var newPost = 2;
-		chrome.storage.sync.set({'comment': newPost});
+		chrome.storage.sync.set({'post': newPost});
 		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
 			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
 			chrome.tabs.sendMessage(tabs[0].id, {
@@ -70,6 +70,61 @@ $(function(){
 		});
 		$('#postStatus').text("all is hidden");
 	});
+//Buttons for the Comments
+
+	//'Unhide comments' button
+	$("button[name='comment-unhide'").click(function(){
+		var newComment = 0;
+		chrome.storage.sync.set({'comment': newComment});
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
+			chrome.tabs.sendMessage(tabs[0].id, {
+				commentMsg: 0
+			});				
+			//so message is sent to 0th tab
+		});
+		$('#commentStatus').text("unhidden");
+	});
+	$("button[name='comment-hide-likes'").click(function(){
+		var newComment = 1;
+		chrome.storage.sync.set({'comment': newComment});
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
+			chrome.tabs.sendMessage(tabs[0].id, {
+				commentMsg: 1
+			});				
+			//so message is sent to 0th tab
+		});
+		$('#commentStatus').text("likes hidden");
+	});
+	$("button[name='comment-hide-all'").click(function(){
+		var newComment = 2;
+		chrome.storage.sync.set({'comment': newComment});
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
+			chrome.tabs.sendMessage(tabs[0].id, {
+				commentMsg: 2
+			});				
+			//so message is sent to 0th tab
+		});
+		$('#commentStatus').text("all is hidden");
+	});
+
+	//Reset button
+	$("button[name='resetButton']").click(function(){
+		//Clears storage and updates text on popup
+		chrome.storage.sync.clear();
+		$('#postStatus').text("text reset");
+		$('#commentStatus').text("text reset");
+		//Tell content script to unhide everything.
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			chrome.tabs.sendMessage(tabs[0].id, {
+				postMsg: 0,
+				commentMsg: 0,
+			});
+		});
+	});
+
 });
 /*
 	//If the posts button is clicked, toggle the removal of likes on comments on or off 

--- a/popup.js
+++ b/popup.js
@@ -37,6 +37,8 @@ $(function(){
 	//For each of the 6 buttons (3 each P and C) do the same thing:
 	//When clicked, set the corresponding val in storage to the new val
 	//and send a message to the content-script
+
+	//Buttons for posts
 	$("button[name='post-unhide'").click(function(){
 		var newPost = 0;
 		chrome.storage.sync.set({'post': newPost});
@@ -69,9 +71,9 @@ $(function(){
 		});
 		$('#postStatus').text("all is hidden");
 	});
-//Buttons for the Comments
 
-	//'Unhide comments' button
+
+	//Buttons for the Comments
 	$("button[name='comment-unhide'").click(function(){
 		var newComment = 0;
 		chrome.storage.sync.set({'comment': newComment});

--- a/popup.js
+++ b/popup.js
@@ -1,17 +1,16 @@
 $(function(){
 	//Check for existing stored values, and set text in popup to that
-	chrome.storage.sync.get(['post', 'comment'], 
-		function(internal){
+	chrome.storage.sync.get(['post', 'comment'], function(internal){
 		//If posts-/commentsTruthDiv already exist, change the text to the stored value
 		//Because it's a boolean, in order to check if it exists, must see if its type is 'undefined'
 		if(typeof internal.post !== 'undefined'){ 
 			if(internal.post == 0){
-				$('#postStatus').text("hidden");
+				$('#postStatus').text("unhidden");
 			}
-			elif(internal.post == 1){
-				$('#postStatus').text("likes are hidden");
+			else if(internal.post == 1){
+				$('#postStatus').text("only likes are hidden");
 			}
-			elif(internal.post == 2){
+			else if(internal.post == 2){
 				$('#postStatus').text("all is hidden");
 			}
 			else{
@@ -20,12 +19,12 @@ $(function(){
 		}
 		if(typeof internal.comment !== 'undefined'){
 			if(internal.post == 0){
-				$('#commentStatus').text("hidden");
+				$('#commentStatus').text("unhidden");
 			}
-			elif(internal.post == 1){
-				$('#commentStatus').text("likes are hidden");
+			else if(internal.post == 1){
+				$('#commentStatus').text("only likes are hidden");
 			}
-			elif(internal.post == 2){
+			else if(internal.post == 2){
 				$('#commentStatus').text("all is hidden");
 			}
 			else{
@@ -45,7 +44,9 @@ $(function(){
 			});				
 			//so message is sent to 0th tab
 		});
+		$('#postStatus').text("unhidden");
 	});
+});
 /*
 	//If the posts button is clicked, toggle the removal of likes on comments on or off 
 	//get the old stored val, and if it exists, new val is opposite bc button has been clicked once

--- a/popup.js
+++ b/popup.js
@@ -46,6 +46,30 @@ $(function(){
 		});
 		$('#postStatus').text("unhidden");
 	});
+	$("button[name='post-hide-likes'").click(function(){
+		var newPost = 1;
+		chrome.storage.sync.set({'comment': newPost});
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
+			chrome.tabs.sendMessage(tabs[0].id, {
+				postMsg: 1
+			});				
+			//so message is sent to 0th tab
+		});
+		$('#postStatus').text("only likes are hidden");
+	});
+	$("button[name='post-hide-all'").click(function(){
+		var newPost = 2;
+		chrome.storage.sync.set({'comment': newPost});
+		chrome.tabs.query({active:true, currentWindow:true},function(tabs){
+			//tabs is an array of all tabs that are ACTIVE and in the CURRENTWINDOW
+			chrome.tabs.sendMessage(tabs[0].id, {
+				postMsg: 2
+			});				
+			//so message is sent to 0th tab
+		});
+		$('#postStatus').text("all is hidden");
+	});
 });
 /*
 	//If the posts button is clicked, toggle the removal of likes on comments on or off 


### PR DESCRIPTION
For comments and posts, 3 buttons each to: block nothing, block only the like #s, or block entire like emojis.

Only bug is when new content loads (either through infinite scroll or loading new comments) it isn't updated with the new settings.